### PR TITLE
Support Gears of War 3 xxx map packages

### DIFF
--- a/LegendaryExplorer/LegendaryExplorerCore/Helpers/GameFileFilters.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Helpers/GameFileFilters.cs
@@ -10,7 +10,7 @@ namespace LegendaryExplorerCore.Helpers
     public static class GameFileFilters
     {
         public const string OpenFileFilter = "Supported package files|*.pcc;*.u;*.upk;*sfm;*udk;*.xxx|All files (*.*)|*.*";
-        public const string UDKFileFilter = "UDK package files|*.upk;*udk";
+        public const string UDKFileFilter = "UDK package files|*.upk;*udk;*.xxx";
         public const string ME1SaveFileFilter = "ME1 package files|*.u;*.upk;*sfm";
         public const string ME3ME2SaveFileFilter = "ME2/ME3 package files|*.pcc";
         public const string LESaveFileFilter = "LE package files|*.pcc";

--- a/LegendaryExplorer/LegendaryExplorerCore/Packages/MEPackageHandler.cs
+++ b/LegendaryExplorer/LegendaryExplorerCore/Packages/MEPackageHandler.cs
@@ -352,16 +352,17 @@ namespace LegendaryExplorerCore.Packages
                 pkg = MEStreamConstructorDelegate(stream, filePath, quickLoad, dataLoadPredicate);
                 MemoryAnalyzer.AddTrackedMemoryItem($"{pkg.Game} MEPackage {Path.GetFileName(filePath)}", new WeakReference(pkg));
             }
-            else if (version is UDKPackage.UDKUnrealVersion2015 or UDKPackage.UDKUnrealVersion2014 or UDKPackage.UDKUnrealVersion2011 or UDKPackage.UDKUnrealVersion2010_09 && licenseVersion == 0)
+            else if (licenseVersion == 0)
             {
-                //UDK
+                // Treat any package with a license version of 0 as a generic UE3/UDK package
+                // so tools can open Gears of War 3 .xxx map files and other UE3 content.
                 stream.Position -= 8; //reset to start
                 pkg = UDKStreamConstructorDelegate(stream, filePath);
                 MemoryAnalyzer.AddTrackedMemoryItem($"UDKPackage {Path.GetFileName(filePath)}", new WeakReference(pkg));
             }
             else
             {
-                throw new FormatException("Not an ME1, ME2, ME3, LE1, LE2, LE3,or UDK (2015) package file.");
+                throw new FormatException("Not an ME1, ME2, ME3, LE1, LE2, LE3, or UE3/UDK package file.");
             }
 
             if (useSharedCache)


### PR DESCRIPTION
## Summary
- handle UE3/UDK packages with license version 0 so Gears of War 3 `.xxx` maps can load
- expose `.xxx` as a selectable UDK package extension

## Testing
- `dotnet test LegendaryExplorer/LegendaryExplorer.sln` *(fails: command not found)*
- `apt-get update` *(fails: 403 forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b0da7a61848328a9937913022dac04